### PR TITLE
Add preruncommand with python version

### DIFF
--- a/downscaling_ap5/env_setup/requirements_wo_modules.txt
+++ b/downscaling_ap5/env_setup/requirements_wo_modules.txt
@@ -13,3 +13,4 @@ pydot
 h5netcdf==1.2.0
 netcdf4==1.6.4
 dask[array]
+graphviz==0.20.1

--- a/downscaling_ap5/mlproject/README.md
+++ b/downscaling_ap5/mlproject/README.md
@@ -48,10 +48,11 @@ Set up a project in Mantik to enable the execution of your experiment. For a ste
 
 1. Set `Python` in `unicore-config-venv.yaml` to the path of your virtual enviroment
 
-```
-Environment:
-  Python: /path/to/<venv-name>
-```
+<pre><code>   PreRunCommand:
+    Command: > 
+      module load Stages/2022 GCCcore/.11.2.0 NCCL/2.11.4-CUDA-11.5 Python/3.9.6;
+      source <b>/path/to/&lt;venv-name&gt;</b>/bin/activate;
+</code></pre>
 
 2. Run your experiment with mantik
 ```

--- a/downscaling_ap5/mlproject/README.md
+++ b/downscaling_ap5/mlproject/README.md
@@ -1,5 +1,9 @@
-### In juwelsbooster
-1. Set python to version 3.9. For this load the following modules:
+# Running Application 5 with Mantik CLI
+To run this application in juwels-booster with the mantik CLI follow these instructions:
+
+1. Login to juwels-booster via SSH. To access juwels-booster via SSH, please follow the instructions provided in this [tutorial](https://apps.fz-juelich.de/jsc/hps/juwels/access.html#ssh-login)
+
+2. Once you are logged in on juwels-booster, set python to version 3.9. For this load the following modules:
 ```
 ml --force purge
 ml use $OTHERSTAGES
@@ -8,25 +12,25 @@ ml GCCcore/.11.2.0
 ml Python/3.9.6
 ```
 
-2. Create a virtual enviroment and activate it:
+3. Create a virtual enviroment and activate it:
 ```
 python -m venv <venv-name>
 source <venv-name>/bin/activate
 ```
 
-3. Clone this git repository and checkout the `develop` branch
+4. Clone this git repository and checkout the `develop` branch
 
 ```
 git clone https://github.com/saragrau4/downscaling_maelstrom.git
 git checkout develop
 ```
 
-3. Install ap5 dependencies with pip. The requirements file is in the `env_setup` file
+5. Install ap5 dependencies with pip. The requirements file is in the `env_setup` file
 ```
 pip install -r downscaling_ap5/env_setup/requirements_wo_modules.txt
 ```
 
-4. Add the following code at the end of the virtual enviroment activate file `<venv-name>/bin/activate`:
+6. Add the following code at the end of the virtual enviroment activation file `<venv-name>/bin/activate`:
 ```
 BASE_DIR="<absolute path to downscaling_maelstrom/downscaling_ap5 directory>"
 # expand PYTHONPATH
@@ -37,16 +41,10 @@ export PYTHONPATH=${BASE_DIR}/models:$PYTHONPATH
 export PYTHONPATH=${BASE_DIR}/postprocess:$PYTHONPATH
 export PYTHONPATH=${BASE_DIR}/preprocess:$PYTHONPATH
 ```
-<br>
 
-### In mantik
+7. The results will be logged to an Experiment on the MLflow tracking server on Mantik. Set up a project in Mantik and create a new Experiment. Note its experiment Id, which will be needed in the submission command. For a step-by-step guide, refer to the Quickstart tutorial available [here](https://mantik-ai.gitlab.io/mantik/ui/quickstart.html).
 
-Set up a project in Mantik to enable the execution of your experiment. For a step-by-step guide, refer to the quickstart tutorial available [here](https://mantik-ai.gitlab.io/mantik/ui/quickstart.html)
-
-
-### In your local mlproject
-
-1. Set `Python` in `unicore-config-venv.yaml` to the path of your virtual enviroment
+8. Update the `unicore-config-venv.yaml` file by specifying the `PreRunCommand` with the path to your virtual environment.
 
 <pre><code>   PreRunCommand:
     Command: > 
@@ -54,7 +52,7 @@ Set up a project in Mantik to enable the execution of your experiment. For a ste
       source <b>/path/to/&lt;venv-name&gt;</b>/bin/activate;
 </code></pre>
 
-2. Run your experiment with mantik
+9. Run your experiment with mantik
 ```
-mantik runs submit <absolute path to downscaling_ap5/mlproject directory> --backend-config unicore-config-venv.yaml --entry-point main --experiment-id <experiment ID> -v
+mantik runs submit <absolute path to downscaling_ap5/mlproject directory> --backend-config unicore-config-venv.yaml --entry-point main --experiment-id <experiment ID> --run-name <run name> -v
 ```

--- a/downscaling_ap5/mlproject/unicore-config-venv.yaml
+++ b/downscaling_ap5/mlproject/unicore-config-venv.yaml
@@ -1,14 +1,10 @@
 UnicoreApiUrl: https://zam2125.zam.kfa-juelich.de:9112/JUWELS/rest/core
 Environment:
-  Python: /p/project/deepacf/maelstrom/grau1/ap5-env
   PreRunCommand:
-    Command: module load Stages/2022 GCCcore/.11.2.0 Python/3.9.6
+    Command: >
+      module load Stages/2022 GCCcore/.11.2.0 NCCL/2.11.4-CUDA-11.5 Python/3.9.6;
+      source /p/project/deepacf/maelstrom/grau1/ap5-env/bin/activate;
     ExecuteOnLoginNode: False
-  Modules:
-    - Stages/2022
-    - GCCcore/.11.2.0
-    - NCCL/2.11.4-CUDA-11.5
-    - Python/3.9.6
   Variables:
     GIT_PYTHON_REFRESH: quiet
 Resources:

--- a/downscaling_ap5/mlproject/unicore-config-venv.yaml
+++ b/downscaling_ap5/mlproject/unicore-config-venv.yaml
@@ -1,6 +1,9 @@
 UnicoreApiUrl: https://zam2125.zam.kfa-juelich.de:9112/JUWELS/rest/core
 Environment:
-  Python: /p/project/deepacf/maelstrom/grau1/test
+  Python: /p/project/deepacf/maelstrom/grau1/ap5-env
+  PreRunCommand:
+    Command: module load Stages/2022 GCCcore/.11.2.0 Python/3.9.6
+    ExecuteOnLoginNode: False
   Modules:
     - Stages/2022
     - GCCcore/.11.2.0


### PR DESCRIPTION
Findings
- Apparently the modules don't vanish when loading them before the activation of the virtual environment
- Also the modules Stages/2022 and Python/3.9.6 should never be loaded after venv activation. If this is done, the local Python will be used instead of the one in the venv causing the system to search within the local Python's site-packages directory instead of the venv's Python's site-packages directory.

For these reasons the backend-config was changed